### PR TITLE
WIP: Implement related relationship access

### DIFF
--- a/src/Controllers/ArticleController.php
+++ b/src/Controllers/ArticleController.php
@@ -34,8 +34,11 @@ class ArticleController extends \Phramework\Examples\JSONAPI\Controller
      * @param string $method       Request method
      * @param array  $headers      Request headers
      */
-    public static function GET(\stdClass $params, string $method, array $headers)
-    {
+    public static function GET(
+        \stdClass $params,
+        string $method,
+        array $headers
+    ) {
         static::handleGET(
             $params,
             Article::class,
@@ -52,8 +55,12 @@ class ArticleController extends \Phramework\Examples\JSONAPI\Controller
      * @param array  $headers      Request headers
      * @param string $id           Resource id
      */
-    public static function GETById(\stdClass $params, string $method, array $headers, string $id)
-    {
+    public static function GETById(
+        \stdClass $params,
+        string $method,
+        array $headers,
+        string $id
+    ) {
         static::handleGETById(
             $params,
             $id,
@@ -69,8 +76,11 @@ class ArticleController extends \Phramework\Examples\JSONAPI\Controller
      * @param string $method       Request method
      * @param array  $headers      Request headers
      */
-    public static function POST(\stdClass $params, string $method, array $headers)
-    {
+    public static function POST(
+        \stdClass $params,
+        string $method,
+        array $headers
+    ) {
         $now = time();
 
         static::handlePOST(
@@ -201,6 +211,34 @@ class ArticleController extends \Phramework\Examples\JSONAPI\Controller
             Article::class,
             [Phramework::METHOD_GET],
             [],
+            []
+        );
+    }
+
+    /**
+     * Access resource's relationship resources
+     * `/article/{id}/{relationship}/` handler
+     * @param \stdClass $params
+     * @param string    $method
+     * @param array     $headers
+     * @param string    $id
+     * @param string    $relationship
+     */
+    public static function byIdRelationshipsRelated(
+        \stdClass $params,
+        string $method,
+        array $headers,
+        string $id,
+        string $relationship
+    ) {
+        static::handleByIdRelationshipsRelated(
+            $params,
+            $method,
+            $headers,
+            $id,
+            $relationship,
+            Article::class,
+            [\Phramework\Phramework::METHOD_GET],
             []
         );
     }

--- a/src/Controllers/Routing.php
+++ b/src/Controllers/Routing.php
@@ -52,6 +52,12 @@ class Routing implements IRouting
                 'byIdRelationships',
                 Phramework::METHOD_ANY
             ],
+            [
+                'article/{id}/{relationship}',
+                ArticleController::class,
+                'byIdRelationshipsRelated',
+                Phramework::METHOD_ANY
+            ],
 
             [
                 'tag/',
@@ -71,6 +77,12 @@ class Routing implements IRouting
                 'byIdRelationships',
                 Phramework::METHOD_ANY
             ],
+            [
+                'tag/{id}/{relationship}',
+                TagController::class,
+                'byIdRelationshipsRelated',
+                Phramework::METHOD_ANY
+            ],
 
             [
                 'user/',
@@ -88,6 +100,12 @@ class Routing implements IRouting
                 'user/{id}/relationships/{relationship}',
                 UserController::class,
                 'byIdRelationships',
+                Phramework::METHOD_ANY
+            ],
+            [
+                'user/{id}/{relationship}',
+                UserController::class,
+                'byIdRelationshipsRelated',
                 Phramework::METHOD_ANY
             ],
         ];

--- a/src/Controllers/TagController.php
+++ b/src/Controllers/TagController.php
@@ -33,8 +33,11 @@ class TagController extends \Phramework\Examples\JSONAPI\Controller
      * @param string $method       Request method
      * @param array  $headers      Request headers
      */
-    public static function GET($params, $method, $headers)
-    {
+    public static function GET(
+        \stdClass $params,
+        string $method,
+        array $headers
+    ) {
         static::handleGET(
             $params,
             Tag::class,
@@ -50,8 +53,12 @@ class TagController extends \Phramework\Examples\JSONAPI\Controller
      * @param array  $headers      Request headers
      * @param string $id           Resource id
      */
-    public static function GETById($params, $method, $headers, string $id)
-    {
+    public static function GETById(
+        \stdClass $params,
+        string $method,
+        array $headers,
+        string $id
+    ) {
         static::handleGETById(
             $params,
             $id,
@@ -70,9 +77,9 @@ class TagController extends \Phramework\Examples\JSONAPI\Controller
      * @param string $relationship Relationship
      */
     public static function byIdRelationships(
-        $params,
-        $method,
-        $headers,
+        \stdClass $params,
+        string $method,
+        array $headers,
         string $id,
         string $relationship
     ) {
@@ -85,6 +92,34 @@ class TagController extends \Phramework\Examples\JSONAPI\Controller
             Tag::class,
             [Phramework::METHOD_GET],
             [],
+            []
+        );
+    }
+
+    /**
+     * Access resource's relationship resources
+     * `/tag/{id}/{relationship}/` handler
+     * @param \stdClass $params
+     * @param string    $method
+     * @param array     $headers
+     * @param string    $id
+     * @param string    $relationship
+     */
+    public static function byIdRelationshipsRelated(
+        \stdClass $params,
+        string $method,
+        array $headers,
+        string $id,
+        string $relationship
+    ) {
+        static::handleByIdRelationshipsRelated(
+            $params,
+            $method,
+            $headers,
+            $id,
+            $relationship,
+            Tag::class,
+            [\Phramework\Phramework::METHOD_GET],
             []
         );
     }

--- a/src/Controllers/UserController.php
+++ b/src/Controllers/UserController.php
@@ -33,8 +33,11 @@ class UserController extends \Phramework\Examples\JSONAPI\Controller
      * @param string $method       Request method
      * @param array  $headers      Request headers
      */
-    public static function GET($params, $method, $headers)
-    {
+    public static function GET(
+        \stdClass $params,
+        string $method,
+        array $headers
+    ) {
         static::handleGET(
             $params,
             User::class,
@@ -50,8 +53,12 @@ class UserController extends \Phramework\Examples\JSONAPI\Controller
      * @param array  $headers      Request headers
      * @param string $id           Resource id
      */
-    public static function GETById($params, $method, $headers, string $id)
-    {
+    public static function GETById(
+        \stdClass $params,
+        string $method,
+        array $headers,
+        string $id
+    ) {
         static::handleGETById(
             $params,
             $id,
@@ -70,9 +77,9 @@ class UserController extends \Phramework\Examples\JSONAPI\Controller
      * @param string $relationship Relationship
      */
     public static function byIdRelationships(
-        $params,
-        $method,
-        $headers,
+        \stdClass $params,
+        string $method,
+        array $headers,
         string $id,
         string $relationship
     ) {
@@ -85,6 +92,34 @@ class UserController extends \Phramework\Examples\JSONAPI\Controller
             User::class,
             [Phramework::METHOD_GET],
             [],
+            []
+        );
+    }
+
+    /**
+     * Access resource's relationship resources
+     * `/user/{id}/{relationship}/` handler
+     * @param \stdClass $params
+     * @param string    $method
+     * @param array     $headers
+     * @param string    $id
+     * @param string    $relationship
+     */
+    public static function byIdRelationshipsRelated(
+        \stdClass $params,
+        string $method,
+        array $headers,
+        string $id,
+        string $relationship
+    ) {
+        static::handleByIdRelationshipsRelated(
+            $params,
+            $method,
+            $headers,
+            $id,
+            $relationship,
+            User::class,
+            [\Phramework\Phramework::METHOD_GET],
             []
         );
     }

--- a/tests/testphase/tag/get-byid-article.json
+++ b/tests/testphase/tag/get-byid-article.json
@@ -1,0 +1,22 @@
+{
+  "meta": {
+    "order": 21
+  },
+  "request": {
+    "url": "tag/{{tagId}}/relationships/article",
+    "method": "GET",
+    "headers": [
+      "{{{headerRequestAccept}}}",
+      "{{{headerRequestContentType}}}"
+    ]
+  },
+  "response": {
+    "statusCode": 200,
+    "headers": {
+      "Content-Type": "{{{headerResponseContentType}}}"
+    },
+    "ruleObjects": [
+      "{{{responseBodyJsonapiResource}}}"
+    ]
+  }
+}

--- a/tests/testphase/tag/get-byid-relationships-article.json
+++ b/tests/testphase/tag/get-byid-relationships-article.json
@@ -1,0 +1,22 @@
+{
+  "meta": {
+    "order": 21
+  },
+  "request": {
+    "url": "tag/{{tagId}}/article",
+    "method": "GET",
+    "headers": [
+      "{{{headerRequestAccept}}}",
+      "{{{headerRequestContentType}}}"
+    ]
+  },
+  "response": {
+    "statusCode": 200,
+    "headers": {
+      "Content-Type": "{{{headerResponseContentType}}}"
+    },
+    "ruleObjects": [
+      "{{{responseBodyJsonapiResource}}}"
+    ]
+  }
+}


### PR DESCRIPTION
JSON API controller should be fixed at

`/var/www/vivanteHealth/ostomate-api/vendor/phramework/jsonapi/src/Controller/Relationships.php:195`

```php
        //Gather ids form relationship
        foreach ($data as $resource) {
            $ids[] = $resource->id;
        }
```

because callback did not returned resources but string[]